### PR TITLE
Added optional permission boundary

### DIFF
--- a/CloudFormation/ASA-iam-key-auto-rotation-and-notifier-solution.yaml
+++ b/CloudFormation/ASA-iam-key-auto-rotation-and-notifier-solution.yaml
@@ -103,6 +103,10 @@ Metadata:
       RecoveryGracePeriod:
         default: Recovery Grace Period
 Parameters:
+  PermissionBoundaryArn:
+    Description: "(Optional) ARN of the IAM Permission Boundary policy to apply to all created IAM roles."
+    Type: String
+    Default: ""
   S3BucketName:
     Description: "S3 Bucket Name where code is located, see the documentation for bucket names https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
     Type: String
@@ -214,6 +218,7 @@ Parameters:
     Type: String
     Description: "Please enter Subnet Id for corresponding VPC  for Lambda Functions"
 Conditions:
+  hasPermissionBoundary: !Not [!Equals [!Ref PermissionBoundaryArn, ""]]
   runInVPC: !Equals [!Ref RunLambdaInVPC, "True"]
 
 Resources:
@@ -239,6 +244,10 @@ Resources:
    NotifierFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If
+        - hasPermissionBoundary
+        - !Ref PermissionBoundaryArn
+        - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -306,6 +315,10 @@ Resources:
     Type: AWS::IAM::Role
     DependsOn: NotifierLambdaFunction
     Properties:
+      PermissionsBoundary: !If
+        - hasPermissionBoundary
+        - !Ref PermissionBoundaryArn
+        - !Ref "AWS::NoValue"
       RoleName: !Ref ExecutionRoleName
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -411,6 +424,10 @@ Resources:
    AccountInventoryFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If
+        - hasPermissionBoundary
+        - !Ref PermissionBoundaryArn
+        - !Ref "AWS::NoValue"
       RoleName: !Ref InventoryExecutionRoleName
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/CloudFormation/ASA-iam-key-auto-rotation-iam-assumed-roles.yaml
+++ b/CloudFormation/ASA-iam-key-auto-rotation-iam-assumed-roles.yaml
@@ -24,6 +24,10 @@ Metadata:
       IAMExemptionGroup:
         default: IAM Exemption Group
 Parameters:
+  PermissionBoundaryArn:
+    Description: "(Optional) ARN of the IAM Permission Boundary policy to apply to all created IAM roles."
+    Type: String
+    Default: ""
   IAMRoleName:
     Description: "Enter the name of IAM Role that the main ASA-iam-key-auto-rotation-and-notifier-solution.yaml CloudFormation template will assume."
     Type: String
@@ -40,6 +44,8 @@ Parameters:
     Description: "Manage IAM Key Rotation exemptions via an IAM Group. Enter the IAM Group name being used to facilitate IAM accounts excluded from auto-key rotation."
     Type: String
     Default: IAMKeyRotationExemptionGroup
+Conditions:
+  hasPermissionBoundary: !Not [!Equals [!Ref PermissionBoundaryArn, ""]]
 
 Resources:
   ##################################################################
@@ -49,6 +55,10 @@ Resources:
   ASAIAMAssumedRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If
+        - hasPermissionBoundary
+        - !Ref PermissionBoundaryArn
+        - !Ref "AWS::NoValue"
       RoleName: !Ref IAMRoleName
       Description: !Sub "IAM Assume Role used by ${PrimaryAccountID}'s ASA-IAM-Access-Key-Rotation-Function Lambda. This role is used to inspect and rotate IAM Keys that are violating the company's key rotation policy."
       AssumeRolePolicyDocument:

--- a/CloudFormation/ASA-iam-key-auto-rotation-list-accounts-role.yaml
+++ b/CloudFormation/ASA-iam-key-auto-rotation-list-accounts-role.yaml
@@ -24,6 +24,10 @@ Metadata:
       PrimaryAccountID:
         default: Primary AWS Account ID
 Parameters:
+  PermissionBoundaryArn:
+    Description: "(Optional) ARN of the IAM Permission Boundary policy to apply to all created IAM roles."
+    Type: String
+    Default: ""
   IAMRoleName:
     Description: "Enter the name of IAM Role that the main ASA-iam-key-auto-rotation-and-notifier-solution.yaml CloudFormation template will assume."
     Type: String
@@ -40,6 +44,8 @@ Parameters:
     Description: "Enter the primary/deployment AWS Account ID that will you will be deploying the ASA-iam-key-auto-rotation-and-notifier-solution.yaml CloudFormation template to."
     Type: String
     Default: ""
+Conditions:
+  hasPermissionBoundary: !Not [!Equals [!Ref PermissionBoundaryArn, ""]]
 
 Resources:
   ##################################################################
@@ -49,6 +55,10 @@ Resources:
   ASAIAMAssumedRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If
+        - hasPermissionBoundary
+        - !Ref PermissionBoundaryArn
+        - !Ref "AWS::NoValue"
       RoleName: !Ref IAMRoleName
       Description: !Sub "IAM Assume Role used by ${PrimaryAccountID}'s ASA-Account-Inventory Lambda. This role is used to list accounts in the Organization."
       AssumeRolePolicyDocument:


### PR DESCRIPTION
Issue https://github.com/aws-samples/aws-iam-access-key-auto-rotation/issues/40

Description of changes:
Added an optional parameter PermissionBoundaryArn. When used the permission boundary provided will be added to all IAM roles deployed by this stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.